### PR TITLE
!feat: add logic to fetch and compute Global Stats

### DIFF
--- a/app/components/hypercert-stats.tsx
+++ b/app/components/hypercert-stats.tsx
@@ -1,0 +1,53 @@
+import React, { Suspense } from "react";
+import { fetchTotalHypercertsSalesData } from "../graphql-queries/hypercerts-sales";
+import { catchError } from "../utils";
+
+const AnalyticsCard = ({ title, value }: { title: string; value: string }) => (
+	<div className="flex flex-col items-center justify-center gap-2 rounded-lg bg-slate-100 p-4">
+		<h1 className="font-semibold text-xl">{title}</h1>
+		<span className="font-semibold text-2xl">{value}</span>
+	</div>
+);
+
+const TotalSalesCard = async ({
+	totalSalesInUSDPromise,
+}: {
+	totalSalesInUSDPromise: Promise<number[]>;
+}) => {
+	const [error, totalSalesInUSD] = await catchError(totalSalesInUSDPromise);
+	if (error) return <>Loading</>;
+	return (
+		<div className="flex flex-col items-center justify-center gap-2 rounded-lg bg-slate-100 p-4">
+			<h1 className="font-semibold text-xl">Total Sales</h1>
+			<span className="font-semibold text-2xl">
+				USD {totalSalesInUSD.reduce((a, b) => a + b, 0)}
+			</span>
+		</div>
+	);
+};
+
+const HypercertAnalytics = async () => {
+	const [error, response] = await catchError(fetchTotalHypercertsSalesData());
+	if (error) return null;
+	const { count, buyers, totalSalesInUSDPromise } = response;
+
+	return (
+		<div className="flex flex-wrap items-center justify-center">
+			<AnalyticsCard
+				title="Total Contributions"
+				value={(count ?? 0).toString()}
+			/>
+			<Suspense
+				fallback={<AnalyticsCard title="Total Sales" value={"Loading..."} />}
+			>
+				<TotalSalesCard totalSalesInUSDPromise={totalSalesInUSDPromise} />
+			</Suspense>
+			<AnalyticsCard
+				title="No. of Contributors"
+				value={buyers.size.toString()}
+			/>
+		</div>
+	);
+};
+
+export default HypercertAnalytics;

--- a/app/graphql-queries/hypercerts-sales.ts
+++ b/app/graphql-queries/hypercerts-sales.ts
@@ -1,0 +1,140 @@
+import { collectionId } from "@/config/hypercert";
+import {
+	calculateBigIntPercentage,
+	typeCastApiResponseToBigInt,
+} from "@/lib/utils";
+import { type ResultOf, graphql } from "gql.tada";
+import { catchError } from "../utils";
+import { fetchHypercertsGraphQL as fetchGraphQL } from "../utils/graphql";
+import { fetchFullHypercertById } from "./hypercerts";
+
+const getHypercertsSalesMetadataQuery = graphql(`
+  query GetSalesMetadata($collection_id: String!) {
+    sales(where: { collection: { eq: $collection_id } }) {
+      count
+      data {
+        buyer
+        hypercert_id
+      }
+    }
+  }
+`);
+
+type HypercertsSalesMetadataQueryResponse = ResultOf<
+	typeof getHypercertsSalesMetadataQuery
+>;
+
+type HypercertsSalesMetadata = {
+	count?: number;
+	buyers: Set<string>;
+	hypercertIds: Set<string>;
+};
+
+const fetchHypercertsSalesMetadata =
+	async (): Promise<HypercertsSalesMetadata> => {
+		const [error, response] = await catchError(
+			fetchGraphQL(getHypercertsSalesMetadataQuery, {
+				collection_id: collectionId,
+			}),
+		);
+		if (error) throw error;
+
+		const buyers = new Set<string>();
+		const hypercertIds = new Set<string>();
+
+		for (const sale of response.sales?.data ?? []) {
+			buyers.add(sale.buyer);
+			if (sale.hypercert_id) {
+				hypercertIds.add(sale.hypercert_id);
+			}
+		}
+
+		const HypercertsSalesMetadata = {
+			count: response.sales.count ?? undefined,
+			buyers,
+			hypercertIds,
+		};
+		return HypercertsSalesMetadata;
+	};
+
+const getSalesByHypercertIdQuery = graphql(`
+  query GetSalesByHypercertId($hypercert_id: String!) {
+    hypercerts(where: { hypercert_id: { eq: $hypercert_id } }) {
+      data {
+        fractions {
+          data {
+            units
+          }
+        }
+        orders {
+          totalUnitsForSale
+          cheapestOrder {
+            pricePerPercentInUSD
+          }
+        }
+      }
+    }
+  }
+`);
+
+const fetchSalesInUSDByHypercertId = async (hypercertId: string) => {
+	const [error, response] = await catchError(
+		fetchGraphQL(getSalesByHypercertIdQuery, {
+			hypercert_id: hypercertId,
+		}),
+	);
+	if (error) throw error;
+
+	const hypercert = response.hypercerts.data
+		? response.hypercerts.data[0]
+		: null;
+	if (!hypercert)
+		throw {
+			message: "Hypercert not found",
+			type: "PAYLOAD",
+		};
+
+	const unitsInEveryFraction =
+		hypercert.fractions?.data?.map((fraction) => {
+			return typeCastApiResponseToBigInt(fraction.units) ?? 0n;
+		}) ?? [];
+	const totalUnitsForSale =
+		typeCastApiResponseToBigInt(hypercert.orders?.totalUnitsForSale) ?? 0n;
+	const pricePerPercentInUSD = Number(
+		hypercert.orders?.cheapestOrder?.pricePerPercentInUSD ?? 0,
+	);
+
+	const totalHypercertUnits = unitsInEveryFraction.reduce(
+		(totalUnitsSold, units) => totalUnitsSold + units,
+		0n,
+	);
+	const unitsSold = totalHypercertUnits - totalUnitsForSale;
+	const percentageOfUnitsSold = calculateBigIntPercentage(
+		unitsSold,
+		totalHypercertUnits,
+	);
+	return pricePerPercentInUSD * (percentageOfUnitsSold ?? 0);
+};
+
+export const fetchTotalHypercertsSalesData = async (): Promise<
+	HypercertsSalesMetadata & { totalSalesInUSDPromise: Promise<number[]> }
+> => {
+	const [error, hypercertSalesMetadata] = await catchError(
+		fetchHypercertsSalesMetadata(),
+	);
+	if (error) throw error;
+
+	const hypercertIdsSet = hypercertSalesMetadata.hypercertIds;
+	const hypercertIds = [...hypercertIdsSet];
+	const salesByHypercertIdPromises = hypercertIds.map((hypercertId) => {
+		return new Promise<number>((resolve) => {
+			fetchSalesInUSDByHypercertId(hypercertId)
+				.then((salesInUSD) => resolve(salesInUSD))
+				.catch(() => resolve(0));
+		});
+	});
+
+	const totalSalesInUSDPromise = Promise.all(salesByHypercertIdPromises);
+
+	return { ...hypercertSalesMetadata, totalSalesInUSDPromise };
+};

--- a/app/graphql-queries/hypercerts.ts
+++ b/app/graphql-queries/hypercerts.ts
@@ -25,7 +25,7 @@ type HypercertIdsByHyperboardIdResponse = ResultOf<
 	typeof hypercertIdsByHyperboardIdQuery
 >;
 
-const fetchHypercertIDs = async () => {
+export const fetchHypercertIDs = async () => {
 	const [error, response] = await catchError<
 		HypercertIdsByHyperboardIdResponse,
 		ApiError
@@ -111,9 +111,9 @@ const fetchHypercertById = async (hypercertId: string): Promise<Hypercert> => {
 		name: hypercert.metadata?.name ?? undefined,
 		description: hypercert.metadata?.description ?? undefined,
 		image: hypercert.metadata?.image ?? undefined,
-		totalUnits: typeCastApiResponseToBigInt(hypercert.units as string),
+		totalUnits: typeCastApiResponseToBigInt(hypercert.units) ?? 0n,
 		unitsForSale: typeCastApiResponseToBigInt(
-			hypercert.orders?.totalUnitsForSale as string,
+			hypercert.orders?.totalUnitsForSale,
 		),
 		pricePerPercentInUSD: pricePerPercentInUSDNumber,
 	};
@@ -280,9 +280,8 @@ export const fetchFullHypercertById = async (
 
 	return {
 		hypercertId,
-		creationBlockTimestamp: typeCastApiResponseToBigInt(
-			hypercert.creation_block_timestamp as string,
-		),
+		creationBlockTimestamp:
+			typeCastApiResponseToBigInt(hypercert.creation_block_timestamp) ?? 0n,
 		creatorAddress: hypercert.creator_address as string,
 		chainId: (hypercert.contract?.chain_id as string) ?? undefined,
 		name: hypercert.metadata?.name ?? undefined,
@@ -290,19 +289,17 @@ export const fetchFullHypercertById = async (
 		work: {
 			scope: hypercert.metadata?.work_scope ?? undefined,
 			from: typeCastApiResponseToBigInt(
-				hypercert.metadata?.work_timeframe_from as string,
+				hypercert.metadata?.work_timeframe_from,
 			),
-			to: typeCastApiResponseToBigInt(
-				hypercert.metadata?.work_timeframe_to as string,
-			),
+			to: typeCastApiResponseToBigInt(hypercert.metadata?.work_timeframe_to),
 		},
 		contributors: hypercert.metadata?.contributors ?? undefined,
 		image: hypercert.metadata?.image ?? undefined,
 		uri: hypercert.uri ?? undefined,
-		totalUnits: typeCastApiResponseToBigInt(hypercert.units as string),
+		totalUnits: typeCastApiResponseToBigInt(hypercert.units) ?? 0n,
 		sales,
 		unitsForSale: typeCastApiResponseToBigInt(
-			hypercert.orders?.totalUnitsForSale as string,
+			hypercert.orders?.totalUnitsForSale,
 		),
 		pricePerPercentInUSD: pricePerPercentInUSDNumber,
 		orders: orders,

--- a/app/graphql-queries/user-hypercerts.ts
+++ b/app/graphql-queries/user-hypercerts.ts
@@ -62,7 +62,7 @@ export const fetchHypercertsByUserId = async (
 			name: hypercert.metadata?.name ?? undefined,
 			description: hypercert.metadata?.description ?? undefined,
 			image: hypercert.metadata?.image ?? undefined,
-			totalUnits: typeCastApiResponseToBigInt(hypercert.units as string),
+			totalUnits: typeCastApiResponseToBigInt(hypercert.units) ?? 0n,
 			unitsForSale: typeCastApiResponseToBigInt(
 				hypercert.orders?.totalUnitsForSale as string,
 			),

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -114,26 +114,6 @@ export default function RootLayout({
 					<div className="flex-1">{children}</div>
 					<Footer />
 				</WagmiContextProvider>
-				<Script
-					id="matomo-tracking"
-					strategy="afterInteractive"
-					// biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-					dangerouslySetInnerHTML={{
-						__html: `
-							var _paq = window._paq = window._paq || [];
-							_paq.push(['trackPageView']);
-							_paq.push(['enableLinkTracking']);
-							(function() {
-								var u="https://psedev.matomo.cloud/";
-								_paq.push(['setTrackerUrl', u+'matomo.php']);
-								_paq.push(['setSiteId', '13']);
-								var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-								g.async=true; g.src='https://cdn.matomo.cloud/psedev.matomo.cloud/matomo.js';
-								s.parentNode.insertBefore(g,s);
-							})();
-						`,
-					}}
-				/>
 			</body>
 		</html>
 	);

--- a/config/hypercert.ts
+++ b/config/hypercert.ts
@@ -1,2 +1,3 @@
 // All hypercerts displayed on the platform must be part of the hyperboard with this ID
 export const hyperboardId = "2b13415d-4149-4896-bb72-67b6417cd7e5";
+export const collectionId = "0xa16DFb32Eb140a6f3F2AC68f41dAd8c7e83C4941";

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -60,17 +60,20 @@ export const calculateBigIntPercentage = (
   return Number((BigInt(numerator) * BigInt(100)) / BigInt(denominator));
 };
 
-export function typeCastApiResponseToBigInt(value: string): bigint;
-export function typeCastApiResponseToBigInt(value: number): bigint;
-export function typeCastApiResponseToBigInt(value: undefined): undefined;
-export function typeCastApiResponseToBigInt(value: null): undefined;
 export function typeCastApiResponseToBigInt(
-  value: string | number | undefined | null
+  value: unknown
 ): bigint | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
-  return BigInt(value);
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "bigint"
+  ) {
+    return BigInt(value);
+  }
+  return undefined;
 }
 
 export function bigintToFormattedDate(timestamp: bigint): string {


### PR DESCRIPTION
The main purpose of the pull request is as follows:
1. Create new graphql queries to efficiently fetch the statistics data.
2. Compute the data from the queries for representation on the home page.
3. Create a component that represents the data on the homepage.

Other improvements:
1. Update the code for better typecasting of data from the graphql queries.

Breaking changes:
1. GraphQL API not working as intended for the statistics data.
2. The component is not yet used on the homepage, due to the first breaking change.